### PR TITLE
Add Linux build and install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 ```bash
 ./scripts/build-sts2-lan-connect.sh
 ./scripts/package-sts2-lan-connect.sh
+./scripts/install-sts2-lan-connect-linux.sh --package-dir ./local-release/sts2_lan_connect
 ```
 
 ```powershell
@@ -71,13 +72,14 @@ powershell -ExecutionPolicy Bypass -File .\scripts\package-sts2-lan-connect-wind
 | DLL | `sts2-lan-connect/.godot/mono/temp/bin/Debug/sts2_lan_connect.dll` | C# 编译输出 |
 | PCK | `sts2-lan-connect/build/sts2_lan_connect.pck` | Godot 打包输出 |
 | 本地打包目录 | `local-release/sts2_lan_connect/` | 本地发布目录 |
-| 本地 zip | `local-release/sts2_lan_connect-v0.1.3-windows.zip` | 本地 Windows 包 |
+| 本地 zip | `local-release/sts2_lan_connect-v0.1.3-linux.zip` / `...-macos.zip` / `...-windows.zip` | 本地平台对应的打包产物 |
 | 仓库发布包 | `releases/sts2_lan_connect-v0.1.3-windows.zip` | 提交到仓库的预编译包 |
 
 安装目标：
 
 - Windows：`<SteamLibrary>/steamapps/common/Slay the Spire 2/mods/sts2_lan_connect/`
 - macOS：`<SteamLibrary>/steamapps/common/Slay the Spire 2/SlayTheSpire2.app/Contents/MacOS/mods/sts2_lan_connect/`
+- Linux：`<SteamLibrary>/steamapps/common/Slay the Spire 2/mods/sts2_lan_connect/`
 
 ## Release 说明
 

--- a/RELEASE_README.md
+++ b/RELEASE_README.md
@@ -14,6 +14,7 @@
 - `sts2_lan_connect.pck`
 - `sts2_lan_connect.json`
 - `STS2_LAN_CONNECT_USER_GUIDE_ZH.md`
+- `install-sts2-lan-connect-linux.sh`
 - `install-sts2-lan-connect-macos.sh`
 - `install-sts2-lan-connect-windows.ps1`
 - `install-sts2-lan-connect-windows.bat`
@@ -34,6 +35,13 @@
 - 本包已经按新结构组织好，直接解压后安装即可
 
 ## 一键安装
+
+### Linux
+
+```bash
+chmod +x ./install-sts2-lan-connect-linux.sh
+./install-sts2-lan-connect-linux.sh
+```
 
 ### macOS
 
@@ -64,6 +72,7 @@ install-sts2-lan-connect-windows.bat
 
 如果只想安装，不想同步存档：
 
+- Linux：`./install-sts2-lan-connect-linux.sh --no-save-sync`
 - macOS：`./install-sts2-lan-connect-macos.sh --no-save-sync`
 - Windows：`powershell -ExecutionPolicy Bypass -File .\install-sts2-lan-connect-windows.ps1 -NoSaveSync`
 

--- a/docs/STS2_LAN_CONNECT_USER_GUIDE_ZH.md
+++ b/docs/STS2_LAN_CONNECT_USER_GUIDE_ZH.md
@@ -46,6 +46,13 @@ powershell -ExecutionPolicy Bypass -File .\install-sts2-lan-connect-windows.ps1
 install-sts2-lan-connect-windows.bat
 ```
 
+### Linux
+
+```bash
+chmod +x ./install-sts2-lan-connect-linux.sh
+./install-sts2-lan-connect-linux.sh
+```
+
 ### macOS
 
 ```bash
@@ -56,6 +63,7 @@ chmod +x ./install-sts2-lan-connect-macos.sh
 如果只想安装 MOD，不想同步存档：
 
 - Windows：追加 `-NoSaveSync`
+- Linux：追加 `--no-save-sync`
 - macOS：追加 `--no-save-sync`
 
 ## 第一次启用

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -36,6 +36,12 @@ powershell -ExecutionPolicy Bypass -File .\scripts\build-sts2-lan-connect-window
 ./scripts/build-sts2-lan-connect.sh
 ```
 
+### Linux
+
+```bash
+./scripts/build-sts2-lan-connect.sh
+```
+
 ## 打包脚本
 
 ### Windows
@@ -45,6 +51,12 @@ powershell -ExecutionPolicy Bypass -File .\scripts\package-sts2-lan-connect-wind
 ```
 
 ### macOS
+
+```bash
+./scripts/package-sts2-lan-connect.sh
+```
+
+### Linux
 
 ```bash
 ./scripts/package-sts2-lan-connect.sh
@@ -68,9 +80,17 @@ chmod +x ./scripts/install-sts2-lan-connect-macos.sh
 ./scripts/install-sts2-lan-connect-macos.sh --package-dir ./local-release/sts2_lan_connect
 ```
 
+### Linux
+
+```bash
+chmod +x ./scripts/install-sts2-lan-connect-linux.sh
+./scripts/install-sts2-lan-connect-linux.sh --package-dir ./local-release/sts2_lan_connect
+```
+
 如果只想安装 MOD，不想同步存档：
 
 - Windows：追加 `-NoSaveSync`
+- Linux：追加 `--no-save-sync`
 - macOS：追加 `--no-save-sync`
 
 ## 输出位置
@@ -90,6 +110,7 @@ chmod +x ./scripts/install-sts2-lan-connect-macos.sh
 | `local-release/sts2_lan_connect/` | 本地发布目录 |
 | `local-release/sts2_lan_connect-v<version>-windows.zip` | 本地 Windows 包 |
 | `local-release/sts2_lan_connect-v<version>-macos.zip` | 本地 macOS 包 |
+| `local-release/sts2_lan_connect-v<version>-linux.zip` | 本地 Linux 包 |
 
 ### 仓库发布包
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -69,7 +69,7 @@
 | `-ModsDir` | `string` | 指定复制到哪个 MOD 目录 |
 | `-SkipInstallCopy` | `switch` | 只构建，不复制到游戏目录 |
 
-### macOS `build-sts2-lan-connect.sh`
+### macOS / Linux `build-sts2-lan-connect.sh`
 
 | 选项 | 含义 |
 | --- | --- |
@@ -89,7 +89,7 @@
 | `-GodotBin` | `string` | Godot 可执行文件 |
 | `-DotnetBin` | `string` | dotnet 可执行文件 |
 
-### macOS `package-sts2-lan-connect.sh`
+### macOS / Linux `package-sts2-lan-connect.sh`
 
 使用环境变量：
 
@@ -120,6 +120,15 @@
 | `--package-dir <path>` | 发布包目录 |
 | `--no-save-sync` | 跳过存档同步 |
 
+### Linux `install-sts2-lan-connect-linux.sh`
+
+| 选项 | 含义 |
+| --- | --- |
+| `--game-dir <path>` | 游戏根目录 |
+| `--data-dir <path>` | 用户存档目录 |
+| `--package-dir <path>` | 发布包目录 |
+| `--no-save-sync` | 跳过存档同步 |
+
 ## 6. 发布包内容契约
 
 本地发布目录 `local-release/sts2_lan_connect/` 内应包含：
@@ -129,6 +138,7 @@
 - `sts2_lan_connect.pck`
 - `README.md`
 - `STS2_LAN_CONNECT_USER_GUIDE_ZH.md`
+- `install-sts2-lan-connect-linux.sh`
 - `install-sts2-lan-connect-macos.sh`
 - `install-sts2-lan-connect-windows.ps1`
 - `install-sts2-lan-connect-windows.bat`

--- a/docs/source-layout.md
+++ b/docs/source-layout.md
@@ -84,6 +84,7 @@
 
 - `install-sts2-lan-connect-windows.ps1`
 - `install-sts2-lan-connect-windows.bat`
+- `install-sts2-lan-connect-linux.sh`
 - `install-sts2-lan-connect-macos.sh`
   把发布包安装到游戏目录，并做一次单向存档同步
 

--- a/scripts/build-sts2-lan-connect.sh
+++ b/scripts/build-sts2-lan-connect.sh
@@ -15,6 +15,7 @@ GODOT_BIN="${GODOT_BIN:-}"
 DOTNET_BIN="${DOTNET_BIN:-}"
 MODS_DIR="${STS2_MODS_DIR:-}"
 SKIP_INSTALL_COPY=0
+HOST_PLATFORM=""
 
 usage() {
   cat <<'EOF'
@@ -78,10 +79,40 @@ die() {
   exit 1
 }
 
+detect_host_platform() {
+  case "$(uname -s)" in
+    Darwin)
+      printf 'macos\n'
+      ;;
+    Linux)
+      printf 'linux\n'
+      ;;
+    *)
+      die "Unsupported host platform '$(uname -s)'."
+      ;;
+  esac
+}
+
+is_valid_game_dir() {
+  local candidate="$1"
+
+  case "$HOST_PLATFORM" in
+    macos)
+      [[ -d "$candidate/SlayTheSpire2.app" ]]
+      ;;
+    linux)
+      [[ -x "$candidate/SlayTheSpire2" && -d "$candidate/data_sts2_linuxbsd_x86_64" ]]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 resolve_dotnet_bin() {
   local candidate
 
-  for candidate in "$DOTNET_BIN" "$(command -v dotnet 2>/dev/null || true)" "$HOME/.dotnet/dotnet"; do
+  for candidate in "$DOTNET_BIN" "$(command -v dotnet 2>/dev/null || true)" "$HOME/.dotnet/dotnet" "/usr/share/dotnet/dotnet"; do
     [[ -n "$candidate" ]] || continue
     [[ -x "$candidate" ]] || continue
     printf '%s\n' "$candidate"
@@ -93,38 +124,71 @@ resolve_dotnet_bin() {
 
 resolve_game_dir() {
   local candidate="$1"
-  local default_root="$HOME/Library/Application Support/Steam/steamapps/common/Slay the Spire 2"
-  local library_file="$HOME/Library/Application Support/Steam/steamapps/libraryfolders.vdf"
   local root=""
   local library_root=""
+  local -a default_roots=()
+  local -a library_files=()
+
+  case "$HOST_PLATFORM" in
+    macos)
+      default_roots=(
+        "$HOME/Library/Application Support/Steam/steamapps/common/Slay the Spire 2"
+      )
+      library_files=(
+        "$HOME/Library/Application Support/Steam/steamapps/libraryfolders.vdf"
+      )
+      ;;
+    linux)
+      default_roots=(
+        "$HOME/.local/share/Steam/steamapps/common/Slay the Spire 2"
+        "$HOME/.steam/steam/steamapps/common/Slay the Spire 2"
+      )
+      library_files=(
+        "$HOME/.local/share/Steam/steamapps/libraryfolders.vdf"
+        "$HOME/.steam/steam/steamapps/libraryfolders.vdf"
+      )
+      ;;
+    *)
+      die "Unsupported host platform '$HOST_PLATFORM'."
+      ;;
+  esac
 
   if [[ -n "$candidate" ]]; then
-    if [[ -d "$candidate/SlayTheSpire2.app" ]]; then
+    if is_valid_game_dir "$candidate"; then
       printf '%s\n' "$candidate"
       return 0
     fi
 
-    if [[ "${candidate##*.}" == "app" && -d "$candidate" ]]; then
+    if [[ "$HOST_PLATFORM" == "macos" && "${candidate##*.}" == "app" && -d "$candidate" ]]; then
+      printf '%s\n' "$(cd "$(dirname "$candidate")" && pwd)"
+      return 0
+    fi
+
+    if [[ "$HOST_PLATFORM" == "linux" && -f "$candidate" && "$(basename "$candidate")" == "SlayTheSpire2" ]]; then
       printf '%s\n' "$(cd "$(dirname "$candidate")" && pwd)"
       return 0
     fi
   fi
 
-  if [[ -d "$default_root/SlayTheSpire2.app" ]]; then
-    printf '%s\n' "$default_root"
-    return 0
-  fi
+  for root in "${default_roots[@]}"; do
+    if is_valid_game_dir "$root"; then
+      printf '%s\n' "$root"
+      return 0
+    fi
+  done
 
-  if [[ -f "$library_file" ]]; then
+  for library_file in "${library_files[@]}"; do
+    [[ -f "$library_file" ]] || continue
+
     while IFS= read -r library_root; do
       [[ -n "$library_root" ]] || continue
       root="${library_root}/steamapps/common/Slay the Spire 2"
-      if [[ -d "$root/SlayTheSpire2.app" ]]; then
+      if is_valid_game_dir "$root"; then
         printf '%s\n' "$root"
         return 0
       fi
     done < <(grep -E '"path"' "$library_file" | sed -E 's/.*"path"[[:space:]]+"([^"]+)".*/\1/' | sed 's/\\\\/\\/g')
-  fi
+  done
 
   die "Could not locate the Slay the Spire 2 game directory. Re-run with --game-dir <path>."
 }
@@ -136,7 +200,9 @@ mono_api_dir_for() {
 
   for candidate in \
     "$executable_dir/GodotSharp/Api/Debug" \
-    "$executable_dir/../Resources/GodotSharp/Api/Debug"; do
+    "$executable_dir/GodotSharp/Api/Release" \
+    "$executable_dir/../Resources/GodotSharp/Api/Debug" \
+    "$executable_dir/../Resources/GodotSharp/Api/Release"; do
     if [[ -d "$candidate" ]]; then
       printf '%s\n' "$candidate"
       return 0
@@ -150,18 +216,46 @@ resolve_godot_bin() {
   local candidate=""
   local lowered=""
   local mono_api_dir=""
+  local -a candidates=()
 
-  for candidate in \
-    "$GODOT_BIN" \
-    "$HOME/.local/bin/godot451" \
-    "$HOME/.local/bin/godot45" \
-    "$HOME/.local/bin/godot4" \
-    "/Applications/Godot.app/Contents/MacOS/Godot" \
-    "$HOME/Applications/Godot.app/Contents/MacOS/Godot" \
-    "$(command -v godot 2>/dev/null || true)" \
-    "$HOME/.local/bin/godot451-mono" \
-    "/Applications/Godot_mono.app/Contents/MacOS/Godot" \
-    "$HOME/Applications/Godot_mono.app/Contents/MacOS/Godot"; do
+  case "$HOST_PLATFORM" in
+    macos)
+      candidates=(
+        "$GODOT_BIN"
+        "$HOME/.local/bin/godot451"
+        "$HOME/.local/bin/godot45"
+        "$HOME/.local/bin/godot4"
+        "/Applications/Godot.app/Contents/MacOS/Godot"
+        "$HOME/Applications/Godot.app/Contents/MacOS/Godot"
+        "$(command -v godot 2>/dev/null || true)"
+        "$HOME/.local/bin/godot451-mono"
+        "/Applications/Godot_mono.app/Contents/MacOS/Godot"
+        "$HOME/Applications/Godot_mono.app/Contents/MacOS/Godot"
+      )
+      ;;
+    linux)
+      candidates=(
+        "$GODOT_BIN"
+        "$HOME/.local/bin/godot451"
+        "$HOME/.local/bin/godot45"
+        "$HOME/.local/bin/godot4"
+        "$HOME/.local/bin/godot"
+        "$HOME/.local/bin/godot451-mono"
+        "$HOME/.local/bin/godot-mono"
+        "/usr/local/bin/godot"
+        "/usr/local/bin/godot4"
+        "/usr/bin/godot"
+        "/usr/bin/godot4"
+        "$(command -v godot 2>/dev/null || true)"
+        "$(command -v godot4 2>/dev/null || true)"
+      )
+      ;;
+    *)
+      die "Unsupported host platform '$HOST_PLATFORM'."
+      ;;
+  esac
+
+  for candidate in "${candidates[@]}"; do
     [[ -n "$candidate" ]] || continue
     [[ -x "$candidate" ]] || continue
 
@@ -197,13 +291,23 @@ assert_supported_godot_version() {
   esac
 }
 
+HOST_PLATFORM="$(detect_host_platform)"
 RESOLVED_DOTNET_BIN="$(resolve_dotnet_bin)"
 RESOLVED_GAME_DIR="$(resolve_game_dir "$STS2_ROOT")"
 RESOLVED_GODOT_BIN="$(resolve_godot_bin)"
-RESOLVED_MODS_DIR="${MODS_DIR:-$RESOLVED_GAME_DIR/SlayTheSpire2.app/Contents/MacOS/mods/$ASSEMBLY_NAME}"
+
+case "$HOST_PLATFORM" in
+  macos)
+    RESOLVED_MODS_DIR="${MODS_DIR:-$RESOLVED_GAME_DIR/SlayTheSpire2.app/Contents/MacOS/mods/$ASSEMBLY_NAME}"
+    ;;
+  linux)
+    RESOLVED_MODS_DIR="${MODS_DIR:-$RESOLVED_GAME_DIR/mods/$ASSEMBLY_NAME}"
+    ;;
+esac
 
 assert_supported_godot_version "$RESOLVED_GODOT_BIN"
 
+log "Using host platform: $HOST_PLATFORM"
 log "Using game dir: $RESOLVED_GAME_DIR"
 log "Using Godot: $RESOLVED_GODOT_BIN"
 mkdir -p "$TEMP_MODS_DIR"

--- a/scripts/install-sts2-lan-connect-linux.sh
+++ b/scripts/install-sts2-lan-connect-linux.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ASSEMBLY_NAME="sts2_lan_connect"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="${PACKAGE_DIR:-$SCRIPT_DIR}"
+USERDATA_DIR="${STS2_USERDATA_DIR:-$HOME/.local/share/SlayTheSpire2}"
+GAME_DIR="${STS2_ROOT:-}"
+SYNC_SAVES=1
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./install-sts2-lan-connect-linux.sh [options]
+
+Options:
+  --game-dir <path>     Slay the Spire 2 game root directory.
+  --data-dir <path>     Slay the Spire 2 user data directory.
+  --package-dir <path>  Directory that contains sts2_lan_connect.dll/.pck/.json.
+  --no-save-sync        Install the mod only; skip save migration/sync.
+  --help                Show this help.
+
+Behavior:
+  1. Copies the mod files into the game's mods/sts2_lan_connect directory.
+  2. Performs a one-way sync from non-modded saves into modded saves.
+  3. Copies only missing files into modded saves and never overwrites existing modded files.
+
+Notes:
+  - Close the game before running this script.
+  - Re-run the script any time you want to re-sync vanilla saves into modded saves.
+EOF
+}
+
+log() {
+  printf '[sts2-lan-connect] %s\n' "$*"
+}
+
+die() {
+  printf '[sts2-lan-connect] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+is_valid_game_dir() {
+  local candidate="$1"
+  [[ -x "$candidate/SlayTheSpire2" && -d "$candidate/data_sts2_linuxbsd_x86_64" ]]
+}
+
+resolve_game_dir() {
+  local candidate="$1"
+  local root=""
+  local library_root=""
+  local -a default_roots=(
+    "$HOME/.local/share/Steam/steamapps/common/Slay the Spire 2"
+    "$HOME/.steam/steam/steamapps/common/Slay the Spire 2"
+  )
+  local -a library_files=(
+    "$HOME/.local/share/Steam/steamapps/libraryfolders.vdf"
+    "$HOME/.steam/steam/steamapps/libraryfolders.vdf"
+  )
+
+  if [[ -n "$candidate" ]]; then
+    if is_valid_game_dir "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+
+    if [[ -f "$candidate" && "$(basename "$candidate")" == "SlayTheSpire2" ]]; then
+      printf '%s\n' "$(cd "$(dirname "$candidate")" && pwd)"
+      return 0
+    fi
+  fi
+
+  for root in "${default_roots[@]}"; do
+    if is_valid_game_dir "$root"; then
+      printf '%s\n' "$root"
+      return 0
+    fi
+  done
+
+  for library_file in "${library_files[@]}"; do
+    [[ -f "$library_file" ]] || continue
+
+    while IFS= read -r library_root; do
+      [[ -n "$library_root" ]] || continue
+      root="${library_root}/steamapps/common/Slay the Spire 2"
+      if is_valid_game_dir "$root"; then
+        printf '%s\n' "$root"
+        return 0
+      fi
+    done < <(grep -E '"path"' "$library_file" | sed -E 's/.*"path"[[:space:]]+"([^"]+)".*/\1/' | sed 's/\\\\/\\/g')
+  done
+
+  die "Could not locate the Slay the Spire 2 game directory. Re-run with --game-dir <path>."
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --game-dir)
+      [[ $# -ge 2 ]] || die "--game-dir requires a value"
+      GAME_DIR="$2"
+      shift 2
+      ;;
+    --data-dir)
+      [[ $# -ge 2 ]] || die "--data-dir requires a value"
+      USERDATA_DIR="$2"
+      shift 2
+      ;;
+    --package-dir)
+      [[ $# -ge 2 ]] || die "--package-dir requires a value"
+      PACKAGE_DIR="$2"
+      shift 2
+      ;;
+    --no-save-sync)
+      SYNC_SAVES=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+if [[ ! -f "$PACKAGE_DIR/$ASSEMBLY_NAME.dll" || ! -f "$PACKAGE_DIR/$ASSEMBLY_NAME.pck" || ! -f "$PACKAGE_DIR/$ASSEMBLY_NAME.json" ]]; then
+  die "Package directory '$PACKAGE_DIR' does not contain $ASSEMBLY_NAME.dll, $ASSEMBLY_NAME.pck, and $ASSEMBLY_NAME.json"
+fi
+
+RESOLVED_GAME_DIR="$(resolve_game_dir "$GAME_DIR")"
+TARGET_MOD_DIR="$RESOLVED_GAME_DIR/mods/$ASSEMBLY_NAME"
+mkdir -p "$TARGET_MOD_DIR"
+
+log "Installing mod files to: $TARGET_MOD_DIR"
+rm -f "$TARGET_MOD_DIR/"*.dll "$TARGET_MOD_DIR/"*.pck "$TARGET_MOD_DIR/"*.json
+cp -f "$PACKAGE_DIR/$ASSEMBLY_NAME.dll" "$TARGET_MOD_DIR/"
+cp -f "$PACKAGE_DIR/$ASSEMBLY_NAME.pck" "$TARGET_MOD_DIR/"
+cp -f "$PACKAGE_DIR/$ASSEMBLY_NAME.json" "$TARGET_MOD_DIR/"
+if [[ -f "$PACKAGE_DIR/STS2_LAN_CONNECT_USER_GUIDE_ZH.md" ]]; then
+  cp -f "$PACKAGE_DIR/STS2_LAN_CONNECT_USER_GUIDE_ZH.md" "$TARGET_MOD_DIR/"
+fi
+
+if [[ "$SYNC_SAVES" -eq 0 ]]; then
+  log "Save sync skipped (--no-save-sync)."
+  exit 0
+fi
+
+if [[ ! -d "$USERDATA_DIR" ]]; then
+  log "User data directory '$USERDATA_DIR' does not exist yet. Installation finished without save sync."
+  exit 0
+fi
+
+profiles_synced=0
+files_copied=0
+
+sync_profile_saves() {
+  local platform_name="$1"
+  local user_dir="$2"
+  local profile_dir="$3"
+  local profile_name
+  local source_saves
+  local dest_profile
+  local dest_saves
+
+  profile_name="$(basename "$profile_dir")"
+  source_saves="$profile_dir/saves"
+  [[ -d "$source_saves" ]] || return
+
+  dest_profile="$user_dir/modded/$profile_name"
+  dest_saves="$dest_profile/saves"
+
+  mkdir -p "$dest_saves"
+
+  while IFS= read -r -d '' source_file; do
+    local relative_path
+    local dest_file
+    relative_path="${source_file#$source_saves/}"
+    dest_file="$dest_saves/$relative_path"
+    mkdir -p "$(dirname "$dest_file")"
+
+    if [[ ! -e "$dest_file" ]]; then
+      cp -f "$source_file" "$dest_file"
+      files_copied=$((files_copied + 1))
+    fi
+  done < <(find "$source_saves" -type f -print0)
+
+  profiles_synced=$((profiles_synced + 1))
+}
+
+for platform_name in steam default; do
+  platform_dir="$USERDATA_DIR/$platform_name"
+  [[ -d "$platform_dir" ]] || continue
+
+  while IFS= read -r -d '' user_dir; do
+    while IFS= read -r -d '' profile_dir; do
+      sync_profile_saves "$platform_name" "$user_dir" "$profile_dir"
+    done < <(find "$user_dir" -mindepth 1 -maxdepth 1 -type d -name 'profile*' -print0)
+  done < <(find "$platform_dir" -mindepth 1 -maxdepth 1 -type d -print0)
+done
+
+log "Save sync finished. Profiles scanned: $profiles_synced, missing files copied: $files_copied"
+log "This is a one-way sync from vanilla saves into modded saves. Existing modded files are never overwritten."

--- a/scripts/package-sts2-lan-connect-windows.ps1
+++ b/scripts/package-sts2-lan-connect-windows.ps1
@@ -37,6 +37,7 @@ Copy-Item $PckFile -Destination $PackageRoot -Force
 Copy-Item $ManifestPath -Destination $PackageRoot -Force
 Copy-Item (Join-Path $RootDir "RELEASE_README.md") -Destination (Join-Path $PackageRoot "README.md") -Force
 Copy-Item $GuidePath -Destination (Join-Path $PackageRoot "STS2_LAN_CONNECT_USER_GUIDE_ZH.md") -Force
+Copy-Item (Join-Path $RootDir "scripts\install-sts2-lan-connect-linux.sh") -Destination $PackageRoot -Force
 Copy-Item (Join-Path $RootDir "scripts\install-sts2-lan-connect-macos.sh") -Destination $PackageRoot -Force
 Copy-Item (Join-Path $RootDir "scripts\install-sts2-lan-connect-windows.ps1") -Destination $PackageRoot -Force
 Copy-Item (Join-Path $RootDir "scripts\install-sts2-lan-connect-windows.bat") -Destination $PackageRoot -Force

--- a/scripts/package-sts2-lan-connect.sh
+++ b/scripts/package-sts2-lan-connect.sh
@@ -12,11 +12,25 @@ DLL_FILE="$PROJECT_DIR/.godot/mono/temp/bin/Debug/$ASSEMBLY_NAME.dll"
 MANIFEST_FILE="$PROJECT_DIR/$ASSEMBLY_NAME.json"
 GUIDE_FILE="$ROOT_DIR/docs/STS2_LAN_CONNECT_USER_GUIDE_ZH.md"
 RELEASE_README="$ROOT_DIR/RELEASE_README.md"
+LINUX_INSTALLER="$ROOT_DIR/scripts/install-sts2-lan-connect-linux.sh"
 MAC_INSTALLER="$ROOT_DIR/scripts/install-sts2-lan-connect-macos.sh"
 WIN_INSTALLER="$ROOT_DIR/scripts/install-sts2-lan-connect-windows.ps1"
 WIN_INSTALLER_BAT="$ROOT_DIR/scripts/install-sts2-lan-connect-windows.bat"
 MOD_VERSION="$(grep -E '"version"' "$MANIFEST_FILE" | head -n 1 | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
 RELEASE_VERSION="v$MOD_VERSION"
+
+case "$(uname -s)" in
+  Darwin)
+    PLATFORM_SUFFIX="macos"
+    ;;
+  Linux)
+    PLATFORM_SUFFIX="linux"
+    ;;
+  *)
+    echo "Unsupported host platform: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
 
 BUILD_ARGS=()
 [[ -n "${STS2_ROOT:-}" ]] && BUILD_ARGS+=(--game-dir "$STS2_ROOT")
@@ -32,11 +46,12 @@ cp "$PCK_FILE" "$PACKAGE_ROOT/"
 cp "$MANIFEST_FILE" "$PACKAGE_ROOT/"
 cp "$RELEASE_README" "$PACKAGE_ROOT/README.md"
 cp "$GUIDE_FILE" "$PACKAGE_ROOT/STS2_LAN_CONNECT_USER_GUIDE_ZH.md"
+cp "$LINUX_INSTALLER" "$PACKAGE_ROOT/"
 cp "$MAC_INSTALLER" "$PACKAGE_ROOT/"
 cp "$WIN_INSTALLER" "$PACKAGE_ROOT/"
 cp "$WIN_INSTALLER_BAT" "$PACKAGE_ROOT/"
 
 cd "$LOCAL_RELEASE_DIR"
-rm -f "${ASSEMBLY_NAME}"*-macos.zip
-zip -qr "${ASSEMBLY_NAME}-${RELEASE_VERSION}-macos.zip" "$ASSEMBLY_NAME"
-echo "Package created at: $LOCAL_RELEASE_DIR/${ASSEMBLY_NAME}-${RELEASE_VERSION}-macos.zip"
+rm -f "${ASSEMBLY_NAME}"*-"$PLATFORM_SUFFIX".zip
+zip -qr "${ASSEMBLY_NAME}-${RELEASE_VERSION}-${PLATFORM_SUFFIX}.zip" "$ASSEMBLY_NAME"
+echo "Package created at: $LOCAL_RELEASE_DIR/${ASSEMBLY_NAME}-${RELEASE_VERSION}-${PLATFORM_SUFFIX}.zip"

--- a/sts2-lan-connect/sts2_lan_connect.csproj
+++ b/sts2-lan-connect/sts2_lan_connect.csproj
@@ -9,18 +9,24 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <UserHome>$([System.Environment]::GetFolderPath(System.Environment+SpecialFolder.UserProfile))</UserHome>
+    <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
+    <IsMacOS Condition="'$(OS)' != 'Windows_NT' and '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'True'">true</IsMacOS>
+    <IsLinux Condition="'$(OS)' != 'Windows_NT' and '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'True'">true</IsLinux>
 
-    <Sts2Root Condition="'$(Sts2Root)' == '' and '$(OS)' == 'Windows_NT'">C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2</Sts2Root>
-    <Sts2Root Condition="'$(Sts2Root)' == '' and '$(OS)' != 'Windows_NT'">$(UserHome)/Library/Application Support/Steam/steamapps/common/Slay the Spire 2</Sts2Root>
+    <Sts2Root Condition="'$(Sts2Root)' == '' and '$(IsWindows)' == 'true'">C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2</Sts2Root>
+    <Sts2Root Condition="'$(Sts2Root)' == '' and '$(IsMacOS)' == 'true'">$(UserHome)/Library/Application Support/Steam/steamapps/common/Slay the Spire 2</Sts2Root>
+    <Sts2Root Condition="'$(Sts2Root)' == '' and '$(IsLinux)' == 'true'">$(UserHome)/.local/share/Steam/steamapps/common/Slay the Spire 2</Sts2Root>
 
     <Sts2MacApp>$(Sts2Root)/SlayTheSpire2.app</Sts2MacApp>
 
-    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(OS)' == 'Windows_NT'">$(Sts2Root)\data_sts2_windows_x86_64</Sts2DataDir>
-    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(OS)' != 'Windows_NT' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">$(Sts2MacApp)/Contents/Resources/data_sts2_macos_arm64</Sts2DataDir>
-    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(OS)' != 'Windows_NT' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'Arm64'">$(Sts2MacApp)/Contents/Resources/data_sts2_macos_x86_64</Sts2DataDir>
+    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(IsWindows)' == 'true'">$(Sts2Root)\data_sts2_windows_x86_64</Sts2DataDir>
+    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(IsMacOS)' == 'true' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">$(Sts2MacApp)/Contents/Resources/data_sts2_macos_arm64</Sts2DataDir>
+    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(IsMacOS)' == 'true' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'Arm64'">$(Sts2MacApp)/Contents/Resources/data_sts2_macos_x86_64</Sts2DataDir>
+    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(IsLinux)' == 'true'">$(Sts2Root)/data_sts2_linuxbsd_x86_64</Sts2DataDir>
 
-    <Sts2ModsDir Condition="'$(Sts2ModsDir)' == '' and '$(OS)' == 'Windows_NT'">$(Sts2Root)\mods\$(AssemblyName)</Sts2ModsDir>
-    <Sts2ModsDir Condition="'$(Sts2ModsDir)' == '' and '$(OS)' != 'Windows_NT'">$(Sts2MacApp)/Contents/MacOS/mods/$(AssemblyName)</Sts2ModsDir>
+    <Sts2ModsDir Condition="'$(Sts2ModsDir)' == '' and '$(IsWindows)' == 'true'">$(Sts2Root)\mods\$(AssemblyName)</Sts2ModsDir>
+    <Sts2ModsDir Condition="'$(Sts2ModsDir)' == '' and '$(IsMacOS)' == 'true'">$(Sts2MacApp)/Contents/MacOS/mods/$(AssemblyName)</Sts2ModsDir>
+    <Sts2ModsDir Condition="'$(Sts2ModsDir)' == '' and '$(IsLinux)' == 'true'">$(Sts2Root)/mods/$(AssemblyName)</Sts2ModsDir>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
  ## Summary

  This PR adds native Linux support for building, packaging, and installing `STS2 LAN Connect`.

  Previously, the repo supported:
  - Windows
  - macOS

  But non-Windows logic was effectively treated as macOS-only. This PR makes Linux an explicit supported platform in the project file, shell tooling, packaging flow, and docs.

  ## What Changed

  - Added explicit Linux platform handling in `sts2_lan_connect.csproj`
  - Added Linux game/data/mod path resolution
  - Updated `scripts/build-sts2-lan-connect.sh` to support:
    - Linux Steam library detection
    - Linux game root detection
    - Linux mod output path
    - broader local `dotnet` / Godot binary discovery
  - Added `scripts/install-sts2-lan-connect-linux.sh`
  - Updated `scripts/package-sts2-lan-connect.sh` to emit `-linux.zip` on Linux hosts
  - Updated Windows packaging to include the Linux installer in release bundles
  - Updated README and docs to document Linux build/package/install usage

  ## Linux Paths Verified

  This was validated against a local native Linux install with:
  - Game root: `~/.local/share/Steam/steamapps/common/Slay the Spire 2`
  - Game data dir: `data_sts2_linuxbsd_x86_64`
  - Save dir: `~/.local/share/SlayTheSpire2`
  - Mod dir: `<game root>/mods/sts2_lan_connect`

  ## Validation

  Validated locally on Ubuntu 24.04 with:
  - `.NET SDK 9`
  - Godot `4.5.1 .NET`

  Checks performed:
  - shell syntax check passed
  - `dotnet build` passed
  - Godot PCK build passed
  - Linux package generation passed
  - Linux install script copied the mod into the expected game `mods/` directory
  - Mod successfully loaded in the native Linux game build
